### PR TITLE
TF analysis updates

### DIFF
--- a/Functions/TFAnalysis/TF_Analysis.m
+++ b/Functions/TFAnalysis/TF_Analysis.m
@@ -251,13 +251,16 @@ try
                 ['Running fourier analysis  (RAM usage: ' ramusage '%)']; ...
                 ['channel: ' num2str(ichan) ', trial: ' num2str(count) ' / ' num2str(numtrials)]; ...
                 })
-            [~,F,T,P] = spectrogram(data(:,ichan,itrial),window,noverlap,nfft,Fs);
+            % de-mean the data to prevent edge artefacts in case no
+            % band-pass or high-pass filter is applied.
+            trial_data = data(:,ichan,itrial) - mean(data(:,ichan,itrial));
+            % calculate the TF transform
+            [~,F,T,P] = spectrogram(trial_data,window,noverlap,nfft,Fs);
             % power to dB
-            % tf(:,:,itrial)=log10(abs(P));
             tf(:,:,itrial)=10*log10(abs(P));
             % apply temporal smoothing
             tf(:,:,itrial)=cfilter2(tf(:,:,itrial),smoothing);
-
+            
             %% monitor RAM usage
             if ispc
                 [~, sys] = memory;

--- a/Functions/TFAnalysis/TF_Analysis.m
+++ b/Functions/TFAnalysis/TF_Analysis.m
@@ -474,11 +474,6 @@ handles.filesizeTF.String = sprintf('TF file size: %i - %i - %i',d1,d2,d3); % di
 % Store averaging in history
 handles.history.average = sprintf('Data averaged over trial/subjects at %s\n\n', datetime);
 
-% remove third dim from EEG struct
-if length(handles.EEG.dims)==3
-    handles.EEG.dims(3) = [];
-end
-
 guidata(hObject,handles);
 plotTF(hObject, handles)
 averagePower_Callback(hObject, eventdata, handles)


### PR DESCRIPTION
Minor improvements:
- Improved parameter settings based on sampling rate and trial length
- Changed power unit from Bell to deciBell
- Use unit of power in TF plots
- De-mean the 'trial' data before TF-transform to prevent edge artefacts with unfiltered data.

Minor bug fixes:
- When averaging tf data over trials the third dimension of the original EEG data was removed. This is incorrect because only the tf data is averaged, not the EEG data. When saving the data the dimension information is updated already.